### PR TITLE
Fix license badge for private repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![MIT License](https://img.shields.io/github/license/inwe-boku/medea.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-green)
 
 _medea_
 =======


### PR DESCRIPTION
shields.io cannot fetch license state for private repositories, so let's just not use the dynamic link. Anyway the caption "MIT license" is static too.