### PR TITLE
Fix minor typo in documentation

### DIFF
--- a/doc/abstract_model.md
+++ b/doc/abstract_model.md
@@ -1,6 +1,6 @@
 ## Basic functionality
 The core of medea is implemented in GAMS and contained in `./src/model/medea_main.gms`. The model is documented in 
-[`./doc/mathematical_description.pdf`](doc/matematical_description.pdf)
+[`mathematical_description.pdf`](./mathematical_description.pdf)
 
 The GAMS model expects data input via a gdx-file named `medea_main_data.gdx`, located in the same directory as the 
 model file. After data preprocessing, the `.gdx`-input is stored in `./data/gdx`.


### PR DESCRIPTION
This should make the link work when displaying the file on Github.